### PR TITLE
Fix event ordering in dashboard. Fix cancel email template

### DIFF
--- a/src/Corvus/EventBundle/Entity/EventRepository.php
+++ b/src/Corvus/EventBundle/Entity/EventRepository.php
@@ -18,8 +18,8 @@ class EventRepository extends EntityRepository
             'SELECT e
             FROM EventBundle:Event e
             LEFT JOIN e.users u
-            WHERE e.host = :uid OR u.id = :uid
-            ORDER BY e.endDateTime ASC'
+            WHERE (e.host = :uid OR u.id = :uid) AND e.status > 0
+            ORDER BY ABS(e.endDateTime - CURRENT_TIMESTAMP()) ASC'
         )->setParameter('uid', $id);
 
         try {
@@ -29,18 +29,6 @@ class EventRepository extends EntityRepository
         }
     }
 
-    /*public function getOrderedUsers($id)
-    {
-        $query = $this->getEntityManager()->createQuery(
-            'SELECT u
-            FROM CorvusMainBundle:User u
-            LEFT JOIN u.events e
-            LEFT JOIN u.orders o
-            WHERE e.id = :eid'
-        )->setParameters(['eid' => $id]);
-
-        return $query->getScalarResult();
-    }*/
     public function getUsersWithOrders($id)
     {
         $query = $this->getEntityManager()->createQuery(

--- a/src/Corvus/EventBundle/Resources/views/Emails/eventCancel.html.twig
+++ b/src/Corvus/EventBundle/Resources/views/Emails/eventCancel.html.twig
@@ -1,6 +1,6 @@
 <h3>Event "{{ event.title }}" has been canceled</h3><br>
 
-Hello, {{ email }}<br>
+Hello, {{ name }}<br>
 
 Event {{ event.title }} has been canceled by {{ event.gethost.getusername }}.<br><br>
 


### PR DESCRIPTION
Fix ordering in dashboard by time difference between now and event ordering timeout. Don't show canceled events. Fix 'Cancel' email template.
