### PR TITLE
Payments hotfix 1207

### DIFF
--- a/src/Corvus/EventBundle/Controller/DefaultController.php
+++ b/src/Corvus/EventBundle/Controller/DefaultController.php
@@ -7,7 +7,6 @@ use Corvus\EventBundle\Entity\Order;
 use Corvus\EventBundle\Entity\Payment;
 use Corvus\EventBundle\Event\EventStatusChangeEvent;
 use Corvus\EventBundle\Event\SendMailsEvent;
-use Corvus\EventBundle\Event\EventStatusChangeEvent;
 use Corvus\EventBundle\EventEvents;
 use Corvus\EventBundle\Form\Type\CartType;
 use Corvus\EventBundle\Form\Type\MissingDishCheckType;

--- a/src/Corvus/EventBundle/Entity/EventRepository.php
+++ b/src/Corvus/EventBundle/Entity/EventRepository.php
@@ -19,7 +19,7 @@ class EventRepository extends EntityRepository
             FROM EventBundle:Event e
             LEFT JOIN e.users u
             WHERE (e.host = :uid OR u.id = :uid) AND e.status > 0
-            ORDER BY ABS(e.endDateTime - CURRENT_TIMESTAMP()) ASC'
+            ORDER BY e.status ASC, ABS(e.endDateTime - CURRENT_TIMESTAMP()) ASC'
         )->setParameter('uid', $id);
 
         try {

--- a/src/Corvus/EventBundle/EventListener/EventAltered.php
+++ b/src/Corvus/EventBundle/EventListener/EventAltered.php
@@ -52,7 +52,12 @@ class EventAltered implements EventSubscriberInterface
 
     public function onEventFoodDelivered(EventStatusChangeEvent $event)
     {
-        $event->getEvent()->setStatus(4);
+        if ($event->getEvent()->getDebtLeft() != 0)
+        {
+            $event->getEvent()->setStatus(4);
+        } else {
+            $event->getEvent()->setStatus(5);
+        }
     }
 
     public function onEventFoodOrdered(EventStatusChangeEvent $event)

--- a/src/Corvus/EventBundle/EventListener/SendMails.php
+++ b/src/Corvus/EventBundle/EventListener/SendMails.php
@@ -274,7 +274,7 @@ class SendMails implements EventSubscriberInterface
                             ->setTo($email)
                             ->setBody(
                                 $this->twig->render(
-                                    '@Event/Emails/foodOrdered.html.twig',
+                                    '@Event/Emails/foodOrdered/foodOrdered.html.twig',
                                     [
                                         'name' => $user->getUsername(),
                                         'event' => $event,


### PR DESCRIPTION
Add status changes after food arrival when there is no debts already. Add status changes when there is no debts left. Ad small change to events ordering in dashboard.
